### PR TITLE
set tf as an alias for terraform

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,16 @@
 tasks:
-  - name: terraform_installation
+  - name: terraform-cli
     before: |
       source ./bin/install_terraform.sh
+      source ./bin/set_tf_alias.sh
+      source ./bin/set_tfrc_token.sh
             
   - name: aws-cli
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
     before: |
       source ./bin/install_aws_cli.sh
+      source ./bin/set_tf_alias.sh
 
 
 vscode:

--- a/README.md
+++ b/README.md
@@ -239,3 +239,7 @@ In the Terraform Cloud platform, go to `Settings -> Variable Sets -> Create Vari
 ### Set TFRC Token [0.8.0]
 
 We created a workaround to [0.7.0] using the [bash script](bin/set_tfrc_token.sh) and set the Token from Terraform cloud as an environmental variable `export TERRAFORM_CLOUD_TOKEN='Your_Terraform_Cloud_Token'`.
+
+### Set tf alias for Terraform [0.9.0]
+
+We set an alias for Terraform as "tf" in the ~/.bash_profile file so we can simply run terraform commands using `tf`. We also automated this using a [bash script](./bin/set_tf_alias.sh) that runs any time we start up gitpod by adding it to the gitpod.yaml file.

--- a/bin/set_tf_alias.sh
+++ b/bin/set_tf_alias.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Check if the alias already exists in the .bash_profile
+grep -q 'alias tf="terraform"' ~/.bash_profile
+
+# $? is a special variable in bash that holds the exit status of the last command executed
+if [ $? -ne 0 ]; then
+    # If the alias does not exist, append it
+    echo 'alias tf="terraform"' >> ~/.bash_profile
+    echo "Alias added successfully."
+else
+    # Inform the user if the alias already exists
+    echo "Alias already exists in .bash_profile."
+fi
+
+# Optional: source the .bash_profile to make the alias available immediately
+source ~/.bash_profile


### PR DESCRIPTION
We set an alias for Terraform to be tf in our bash profile[~/.bash_profile]. We went ahead to automate this using a bash script which runs every time gitpod starts up.