### PR TITLE
Deployed CloudFront Distribution, OAC and S3 Bucket Policy

### DIFF
--- a/journal/Week-1.md
+++ b/journal/Week-1.md
@@ -1,5 +1,29 @@
 # Terraform Beginner Bootcamp 2023 - Week-1
 
+## Fixing Tags
+
+[How to Delete Local and Remote Tags on Git](https://devconnected.com/how-to-delete-local-and-remote-tags-on-git/)
+
+Locall delete a tag
+```sh
+git tag -d <tag_name>
+```
+
+Remotely delete tag
+
+```sh
+git push --delete origin tagname
+```
+
+Checkout the commit that you want to retag. Grab the sha from your Github history.
+
+```sh
+git checkout <SHA>
+git tag M.M.P
+git push --tags
+git checkout main
+```
+
 ## Root Module Structure [1.1.0]
 
 The standard module structure is a file and directory layout recommended for reusable modules distributed in separate repositories. The standard module structure expects the layout documented below:
@@ -216,3 +240,55 @@ resource "aws_s3_object" "file" {
   etag = filemd5(${path.root}/public/index.html)
 }
 ```
+
+
+## CDN Implementation with AWS CloudFront [1.5.0]
+
+In this Task, we implemented a CDN using `aws_cloudfront_distribution` and `aws_cloudfront_origin_access_control`. We also gave the origin access control a **"read-only"** access permission to access the S3 bucket using `aws_s3_bucket_policy`. I also set all my resource and data block names to **"terratown"** for ease of reference.
+
+### Terraform concepts implemented
+
+To make our .tf files not too long and easily readable, we created a `resource-cdn.tf` to handle the CloudFront configurations and `resource-storage.tf` to handle the s3 configurations. We also implemented two new Terraform concepts; Terraform Data Sources and Terraform Locals.
+
+#### Terraform Data Sources
+
+This allows use to source data from cloud resources.
+
+This is useful when we want to reference cloud resources without importing them.
+
+```tf
+data "aws_caller_identity" "current" {}
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+```
+[Data Sources](https://developer.hashicorp.com/terraform/language/data-sources)
+
+
+#### Terraform Locals
+
+Locals allows us to define local variables.
+It can be very useful when we need transform data into another format and have referenced a varaible.
+
+```tf
+locals {
+  s3_origin_id = "MyS3Origin"
+}
+```
+[Local Values](https://developer.hashicorp.com/terraform/language/values/locals)
+
+We also made use of jsonencode to create the json policy in the locals.tf and referenced it in the resource-storage.tf file.
+
+```tf
+> jsonencode({"hello"="world"})
+{"hello":"world"}
+```
+
+[jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode)
+
+### Content Type
+We had to set the content type of our website files in the `aws_s3_object` resource to enable s3 serve us the webpages when accessed through a browser instead of download it as an attachment.
+
+The content_type argument is used to specify the MIME type of the object stored in an AWS S3 bucket using Terraform. The MIME type is a standard way of indicating the nature and format of a document or file. It can help applications to handle the object appropriately, such as displaying it in a browser or downloading it as an attachment. [Read More Here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+

--- a/modules/terrahouse_aws/locals.tf
+++ b/modules/terrahouse_aws/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  s3_origin_id = "MyS3Origin"
+  content_type = "text/html"
+  policy = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = {
+      "Sid" = "AllowCloudFrontServicePrincipalReadOnly",
+      "Effect" = "Allow",
+      "Principal" = {
+        "Service" = "cloudfront.amazonaws.com"
+      },
+      "Action" = "s3:GetObject",
+      "Resource" = "arn:aws:s3:::${aws_s3_bucket.terratown.id}/*",
+      "Condition" = {
+      "StringEquals" = {
+          #"AWS:SourceArn": data.aws_caller_identity.terratown.arn
+          "AWS:SourceArn" = "arn:aws:cloudfront::${data.aws_caller_identity.terratown.account_id}:distribution/${aws_cloudfront_distribution.terratown.id}"
+        }
+      }
+    }
+  })
+}

--- a/modules/terrahouse_aws/main.tf
+++ b/modules/terrahouse_aws/main.tf
@@ -7,33 +7,5 @@ terraform {
   }
 }
 
-# Creating S3 Bucket [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket]
-resource "aws_s3_bucket" "bucket" {
-  bucket = var.bucket_name
-
-  tags = {
-    UserUuid = var.user_uuid
-  }
-  }
-
-# Configuring S3 for Static Website [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration]
-resource "aws_s3_bucket_website_configuration" "website" {
-  bucket = aws_s3_bucket.bucket.id
-
-  index_document {
-    suffix = var.website_files.index
-  }
-
-  error_document {
-    key = var.website_files.error
-  }
-}
-
-# Upload website files to S3 Bucket [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object]
-resource "aws_s3_object" "file" {
-  for_each = var.file_path
-  bucket = aws_s3_bucket.bucket.bucket
-  key    = "${each.key}.html"
-  source = each.value
-  etag = filemd5(each.value)
-}
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity
+data "aws_caller_identity" "terratown" {}

--- a/modules/terrahouse_aws/outputs.tf
+++ b/modules/terrahouse_aws/outputs.tf
@@ -1,7 +1,11 @@
 output "bucket_name" {
-  value = aws_s3_bucket.bucket.bucket
+  value = aws_s3_bucket.terratown.bucket
 }
 
 output "website_url" {
-  value = aws_s3_bucket_website_configuration.website.website_endpoint
+  value = aws_s3_bucket_website_configuration.terratown.website_endpoint
+}
+
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.terratown.domain_name
 }

--- a/modules/terrahouse_aws/resource-cdn.tf
+++ b/modules/terrahouse_aws/resource-cdn.tf
@@ -1,0 +1,60 @@
+# https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control
+resource "aws_cloudfront_origin_access_control" "terratown" {
+  name   = "OAC-${var.bucket_name}"
+  description  = "Origin Access Controls for Static Website Hosting on ${var.bucket_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior  = "always"
+  signing_protocol  = "sigv4"
+}
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution
+resource "aws_cloudfront_distribution" "terratown" {
+  origin {
+    domain_name              = aws_s3_bucket.terratown.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.terratown.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Static website hosting for: ${var.bucket_name}"
+  default_root_object = var.website_files.index
+
+  #aliases = ["mysite.example.com", "yoursite.example.com"] we do not need this for now since we are not implementing a custom domain name
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  tags = {
+    UserUuid = var.user_uuid
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/modules/terrahouse_aws/resource-storage.tf
+++ b/modules/terrahouse_aws/resource-storage.tf
@@ -1,0 +1,37 @@
+# Creating S3 Bucket [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket]
+resource "aws_s3_bucket" "terratown" {
+  bucket = var.bucket_name
+
+  tags = {
+    UserUuid = var.user_uuid
+  }
+  }
+
+# Configuring S3 for Static Website [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration]
+resource "aws_s3_bucket_website_configuration" "terratown" {
+  bucket = aws_s3_bucket.terratown.id
+
+  index_document {
+    suffix = var.website_files.index
+  }
+
+  error_document {
+    key = var.website_files.error
+  }
+}
+
+# Upload website files to S3 Bucket [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object]
+resource "aws_s3_object" "terratown" {
+  for_each = var.file_path
+  bucket = aws_s3_bucket.terratown.bucket
+  key    = "${each.key}.html"
+  source = each.value
+  content_type = local.content_type
+  etag = filemd5(each.value)
+}
+
+resource "aws_s3_bucket_policy" "terratown" {
+  bucket = aws_s3_bucket.terratown.bucket
+  #policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+  policy = local.policy
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "website_url" {
   description = "Website endpoint"
   value       = module.terrahouse_aws.website_url
 }
+
+output "cloudfront_domain_name" {
+  description = "Domain name corresponding to the distribution"
+  value = module.terrahouse_aws.cloudfront_domain_name
+}

--- a/public/error.html
+++ b/public/error.html
@@ -1,1 +1,11 @@
-Oops! Error!
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error</title>
+</head>
+<body>
+    <p>Error!</p>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,1 +1,11 @@
-Hello Kunle!
+Hello <!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello Terraformers</title>
+</head>
+<body>
+    <h1>Hello Terraformers</h1>
+</body>
+</html>


### PR DESCRIPTION
We implemented a content delivery network using AWS CloudFront by configuring:

- [x] CloudFront Distribution
- [x] CloudFront Origin Access Controls
- [x] Bucket Policy

- I also renamed all my Resource and Data Block names to "terratown" for ease of reference.
- I created a separate locals.tf file to handle my local variables.
- We also added a "content_type = text/html" argument to our previously deployed s3_object for the files to be served as a webpage.