### PR TITLE
set up content versioning with Terraform data and lifecycle argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,9 @@ module "terrahouse_aws" {
     index = var.file_path.index
     error = var.file_path.error
   }
+
+  # Implementing content versioning for website files
+  content_version = var.content_version
 }
 
 

--- a/modules/terrahouse_aws/main.tf
+++ b/modules/terrahouse_aws/main.tf
@@ -9,3 +9,4 @@ terraform {
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity
 data "aws_caller_identity" "terratown" {}
+

--- a/modules/terrahouse_aws/resource-storage.tf
+++ b/modules/terrahouse_aws/resource-storage.tf
@@ -28,10 +28,18 @@ resource "aws_s3_object" "terratown" {
   source = each.value
   content_type = local.content_type
   etag = filemd5(each.value)
+  lifecycle {
+    replace_triggered_by = [ terraform_data.content_version.output ]
+    ignore_changes = [ etag ]
+  }
 }
 
 resource "aws_s3_bucket_policy" "terratown" {
   bucket = aws_s3_bucket.terratown.bucket
   #policy = data.aws_iam_policy_document.allow_access_from_another_account.json
   policy = local.policy
+}
+
+resource "terraform_data" "content_version" {
+  input = var.content_version
 }

--- a/modules/terrahouse_aws/variables.tf
+++ b/modules/terrahouse_aws/variables.tf
@@ -34,3 +34,13 @@ variable "file_path" {
   error_message = "One or both of the provided file paths do not exist."
   }
 }
+
+variable "content_version" {
+  description = "The content version. Should be a positive integer starting at 1."
+  type        = number
+
+  validation {
+    condition     = var.content_version > 0 && floor(var.content_version) == var.content_version
+    error_message = "The content_version must be a positive integer starting at 1."
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "website_url" {
 
 output "cloudfront_domain_name" {
   description = "Domain name corresponding to the distribution"
-  value = module.terrahouse_aws.cloudfront_domain_name
+  value       = module.terrahouse_aws.cloudfront_domain_name
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,3 +8,4 @@ file_path = {
   index = "/workspace/terraform-beginner-bootcamp-2023/public/index.html"
   error = "/workspace/terraform-beginner-bootcamp-2023/public/error.html"
 }
+content_version = 1

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,8 @@ variable "file_path" {
   description = "Path of the index and error document for the website"
   type        = map(string)
 }
+
+variable "content_version" {
+  description = "The content version. Should be a positive integer starting at 1."
+  type        = number
+}


### PR DESCRIPTION
We implemented content by adding:

- [x] terraform_data for content_version
- [x] A lifecycle argument to our s3 object block