### PR TITLE
Invalidated CloudFront Distribution

### DIFF
--- a/modules/terrahouse_aws/resource-cdn.tf
+++ b/modules/terrahouse_aws/resource-cdn.tf
@@ -58,3 +58,17 @@ resource "aws_cloudfront_distribution" "terratown" {
     cloudfront_default_certificate = true
   }
 }
+
+
+resource "terraform_data" "invalidate_cache" {
+  triggers_replace = terraform_data.content_version.output
+
+  provisioner "local-exec" {
+    command = <<EOF
+      aws cloudfront create-invalidation \
+      --distribution-id ${aws_cloudfront_distribution.terratown.id} \
+      --paths '/*'
+    EOF
+
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,9 @@ Hello <!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hello Terraformers</title>
+    <title>Terraformers</title>
 </head>
 <body>
-    <h1>Hello Terraformers</h1>
+    <h1>Hello Terraformers!!</h1>
 </body>
 </html>


### PR DESCRIPTION
To remove website files from the edge caches before they expire, we had to implement;

- [x] Terraform data for content versioning
- [x] Trigger cloudfront distribution invalidation 